### PR TITLE
change return to continue

### DIFF
--- a/GildedRose/Program.cs
+++ b/GildedRose/Program.cs
@@ -69,7 +69,7 @@ namespace GildedRose
             foreach (var item in Items)
             {
                 var legendary = item.Name =="Sulfuras, Hand of Ragnaros";
-                if (legendary) return;
+                if (legendary) continue;
 
                 item.SellIn--;
                 var expired = item.SellIn<0;


### PR DESCRIPTION
I mistakenly wrote return. I figured that it would fail if the first item was legendary because the method would stop totally.  Therefore changed to continue.